### PR TITLE
Make indentationRules more specific

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -11,8 +11,8 @@
     "lineComment": ";"
   },
   "indentationRules": {
-    "increaseIndentPattern": ".proc|.else|for|ifc|ifu",
-    "decreaseIndentPattern": ".else|.end",
+    "increaseIndentPattern": "^\\s*(?:\\.proc|\\.else|for|ifc|ifu)",
+    "decreaseIndentPattern": "^\\s*(?:\\.else|\\.end)",
   },
   "wordPattern": "",
   "surroundingPairs": [


### PR DESCRIPTION
This prevents unwanted indentation changes, e.g. typing the word `blend` should not cause unindentation.